### PR TITLE
Add option to keep drawer open when view disappears

### DIFF
--- a/Source/SideMenuController+CustomTypes.swift
+++ b/Source/SideMenuController+CustomTypes.swift
@@ -60,6 +60,7 @@ public extension SideMenuController {
         public struct Interaction {
             public var panningEnabled = true
             public var swipingEnabled = true
+            public var closeOnViewDisappear = true
             public var menuButtonAccessibilityIdentifier: String?
         }
         

--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -179,7 +179,7 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
     
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if sidePanelVisible {
+        if sidePanelVisible && self._preferences.interaction.closeOnViewDisappear {
             toggle()
         }
     }


### PR DESCRIPTION
This PR adds a new preference option to keep the side menu open when `viewWillDisappear` is called.

```
SideMenuController.preferences.interaction.closeOnViewDisappear = false
```