### PR TITLE
Hide keyboard on toggle

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -39,6 +39,10 @@ public extension SideMenuController {
         
         if !transitionInProgress {
             if !sidePanelVisible {
+                
+                // Dismiss any showing keyboard in the centerViewController
+                self.centerViewController.view.endEditing(true)
+                
                 prepare(sidePanelForDisplay: true)
             }
             


### PR DESCRIPTION
Hides any visible keyboard in the centerViewController once toggle is
called. Solves problem with UIKeyboard Notifications when switching centerView controllers.