### PR TITLE
Disabling opening the side menu

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -406,7 +406,10 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
         return screenSize.width < screenSize.height
     }
     
+    open var sidePanelDisabled = false
+    
     var canDisplaySideController: Bool {
+        guard !sidePanelDisabled else { return false }
         return sideViewController != nil
     }
     


### PR DESCRIPTION
Sometimes it would be nice to be able to disable opening the side menu even while there is a view controller. I'm not entirely sure about the naming of the property.

My use case is that I have a subview of my navigation controller where I want to disable the side menu. I don't want to completely remove it just for this one view.