### PR TITLE
sideMenuButton now is on the right, even when there are existing navigation items

### DIFF
--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -77,7 +77,12 @@ public extension UINavigationController {
         let spacer = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.fixedSpace, target: nil, action: nil)
         spacer.width = -10
         
-        items.append(contentsOf: positionLeft ? [spacer, item] : [item, spacer])
+        if positionLeft {
+            items.append(contentsOf: positionLeft ? [spacer, item] : [item, spacer])
+        } else {
+            items.insert(contentsOf: [spacer, item], at: 0)
+        }
+        
         return items
     }
 }

--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -78,7 +78,7 @@ public extension UINavigationController {
         spacer.width = -10
         
         if positionLeft {
-            items.append(contentsOf: positionLeft ? [spacer, item] : [item, spacer])
+            items.append(contentsOf: [spacer, item])
         } else {
             items.insert(contentsOf: [spacer, item], at: 0)
         }


### PR DESCRIPTION
sideMenuButton now is on the right, even when there are existing navigation items. Previously when positionLeft was false, and there where existing navbar items it would show on the left of those, like:

MenuButton Item1 Item2

Now it is:

Item1 Item2 MenuButton