### PR TITLE
Fixing snapshot zoom issues on "plus" devices in Zoom-mode

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -290,6 +290,8 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
                 centerPanelSShot = nil
             } else if centerPanelSShot == nil {
                 centerPanelSShot = UIScreen.main.snapshotView(afterScreenUpdates: false)
+                // We must reset the frame to the actual bounds, because a "zoomed" Plus device might screw this up
+                centerPanelSShot!.frame = self.view.bounds
                 centerPanel.addSubview(centerPanelSShot!)
             }
         }


### PR DESCRIPTION
Hi there,

thx for this awesome lib, but I think I found a problem:

On Plus-devices the center-panel that will transition to the side will be rendered too big at the end of the transition if the app is running "zoomed".

Why? The UIScreen.main.snappshotView(...) returns a UIView that will match the actual UIScreen, not the "zoomed" one, so we need to set the frame accordingly.

I have tested this in my app and it seems to work, but I haven't checked all possibilities. If you think there might be a problem in a certain config let me know and I check it out.