### PR TITLE
Update UIKitExtensions.swift

### DIFF
--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -43,7 +43,7 @@ public extension UINavigationController {
             return
         }
         
-        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 22, height: 22))
         button.accessibilityIdentifier = SideMenuController.preferences.interaction.menuButtonAccessibilityIdentifier
         button.setImage(image, for: .normal)
         button.addTarget(sideMenuController, action: #selector(SideMenuController.toggle), for: UIControlEvents.touchUpInside)


### PR DESCRIPTION
Building the project against iOS11 we have spotted that the UIBarButton is not in the correct location on the left navigation bar looking at the apple documentation it recommends that the standard non retina size of the button should be 22px x 22px.