### PR TITLE
Fixed display issues for iPhone X

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -444,17 +444,16 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
     fileprivate var sidePanelFrame: CGRect {
         var sidePanelFrame: CGRect
         
-        let diff: CGFloat = previousStatusBarHeight - statusBarHeight
         let panelWidth = _preferences.drawing.sidePanelWidth
         
         if sidePanelPosition.isPositionedUnder {
             sidePanelFrame = CGRect(x: sidePanelPosition.isPositionedLeft ? 0 :
-                screenSize.width - panelWidth, y: 0, width: panelWidth, height: screenSize.height + diff)
+                screenSize.width - panelWidth, y: statusBarHeight, width: panelWidth, height: screenSize.height - statusBarHeight)
         } else {
             if sidePanelVisible {
-                sidePanelFrame = CGRect(x: sidePanelPosition.isPositionedLeft ? 0 : screenSize.width - panelWidth, y: 0, width: panelWidth, height: screenSize.height + diff)
+                sidePanelFrame = CGRect(x: sidePanelPosition.isPositionedLeft ? 0 : screenSize.width - panelWidth, y: statusBarHeight, width: panelWidth, height: screenSize.height - statusBarHeight)
             } else {
-                sidePanelFrame = CGRect(x: sidePanelPosition.isPositionedLeft ? -panelWidth : screenSize.width, y: 0, width: panelWidth, height: screenSize.height + diff)
+                sidePanelFrame = CGRect(x: sidePanelPosition.isPositionedLeft ? -panelWidth : screenSize.width, y: statusBarHeight, width: panelWidth, height: screenSize.height - statusBarHeight)
             }
         }
         


### PR DESCRIPTION
- Fixed iPhone X sidebar not fully to bottom
- Also fixed flickering on status bar when opening the sidemenucontroller

Manually tested for iOS 10 and iOS 11 and on smaller devices too.

This fixed following issue: https://github.com/teodorpatras/SideMenuController/issues/136